### PR TITLE
Fix Protect panic handling

### DIFF
--- a/util/protect.go
+++ b/util/protect.go
@@ -5,7 +5,7 @@ import "context"
 func Protect(ctx context.Context, fn func() error) {
 	logger := LogFromCtx(ctx)
 
-	go func() {
+	defer func() {
 		if r := recover(); r != nil {
 			logger.Error("panic", "r", r)
 		}


### PR DESCRIPTION
## Summary
- recover from `fn()` panics using a deferred function

## Testing
- `gofmt -w util/protect.go`
- `GOTOOLCHAIN=local go fmt ./...` *(fails: go.mod requires go >= 1.24.3)*

------
https://chatgpt.com/codex/tasks/task_e_684c480f399c83289b5137a7db8e9eff